### PR TITLE
fix: close html, body CSS rule in buildSplitLayout

### DIFF
--- a/src/index.js
+++ b/src/index.js
@@ -1505,6 +1505,7 @@ function buildSplitLayout(events, displayDates, layout, layoutKey, dailyPeriods,
     // wide/split/tri: transparent so the display hardware charcoal texture shows
     // through. full: solid dark background — the display fills the whole screen.
     '  overflow: hidden; background: ' + (darkBg || layoutKey === 'full' ? DARK_BG_COLOR : 'transparent') + '; color: rgba(255,255,255,0.92);' +
+    '}' +
     '.outer {' +
     '  width: '  + width  + 'px; height: ' + height + 'px;' +
     '  padding: ' + pad + 'px;' +


### PR DESCRIPTION
## Summary

- Inserts a single `'}' +` line in `buildSplitLayout` (`src/index.js` ~line 1508) to close the `html, body {}` CSS rule before `.outer {`.
- Fixes #29 (priority-1 audit issue: malformed CSS — missing closing brace for `html, body` in `buildSplitLayout`).
- The equivalent blocks in `buildStripLayout` (~line 1994) and `renderErrorPage` (~line 2154) were already correct and are unchanged.

## Brace count verification

| | Opening `{` | Closing `}` |
|---|---|---|
| Before fix | 47 | 46 |
| After fix  | 47 | 47 |

## Test plan

- [ ] Render the split layout and inspect the generated `<style>` tag — confirm `html, body { … }` is a self-contained rule and `.outer { … }` is a sibling, not nested inside it.
- [ ] Verify no visual regression in wide/split/tri layouts (transparent background) and full layout (solid dark background).
- [ ] Confirm `buildStripLayout` and `renderErrorPage` CSS blocks are untouched.