### PR TITLE
fix: remove NWS_USER_AGENT from secret validation

### DIFF
--- a/src/index.js
+++ b/src/index.js
@@ -204,7 +204,7 @@ export default {
     // Matches the probationary-firefighter-display ?bg=dark parameter behaviour.
     const darkBg = sanitizeParam(url.searchParams.get('bg')) === 'dark';
 
-    var REQUIRED_SECRETS = ['NEXTCLOUD_URL', 'NEXTCLOUD_USERNAME', 'NEXTCLOUD_PASSWORD', 'NWS_USER_AGENT'];
+    var REQUIRED_SECRETS = ['NEXTCLOUD_URL', 'NEXTCLOUD_USERNAME', 'NEXTCLOUD_PASSWORD'];
     for (var i = 0; i < REQUIRED_SECRETS.length; i++) {
       var key = REQUIRED_SECRETS[i];
       if (!env[key]) {


### PR DESCRIPTION
## Summary

- `NWS_USER_AGENT` is defined in `wrangler.toml` as a plain `[vars]` entry and is not sensitive
- It should not be validated alongside Cloudflare secrets
- Removed from the `REQUIRED_SECRETS` array in `src/index.js`

`wrangler.toml` has also been updated to explicitly define the var under `[env.staging.vars]` since Wrangler does not automatically inherit top-level `[vars]` in named environments.

## Test plan

- [ ] Deploy to staging and confirm the worker starts without errors
- [ ] Confirm weather data still loads (NWS_USER_AGENT is still available via `env.NWS_USER_AGENT` from wrangler.toml vars)
- [ ] Confirm a missing Nextcloud secret still returns a 500 error as expected