### PR TITLE
fix: accept HEAD requests for UptimeRobot health monitoring

### DIFF
--- a/src/index.js
+++ b/src/index.js
@@ -179,9 +179,13 @@ const SHOW_WEATHER = false;
 export default {
   async fetch(request, env) {
 
-    // Reject non-GET requests with a generic error to reduce attack surface.
-    if (request.method !== 'GET') {
-      return new Response('Method not allowed', { status: 405 });
+    // Allow GET and HEAD (HEAD is used by UptimeRobot health monitoring).
+    // All other methods are rejected to reduce attack surface.
+    if (request.method !== 'GET' && request.method !== 'HEAD') {
+      return new Response('Method not allowed', {
+        status: 405,
+        headers: { 'Allow': 'GET, HEAD' },
+      });
     }
 
     // Parse and validate the layout URL parameter before the try block so
@@ -244,10 +248,12 @@ export default {
         details.push('nextcloud: unreachable (' + (e && e.message ? e.message : String(e)) + ')');
       }
 
-      return new Response(
+      const healthBody =
         'status: ' + healthStatus + '\n' +
         'worker: calendar-display\n' +
-        details.join('\n') + '\n',
+        details.join('\n') + '\n';
+      return new Response(
+        request.method === 'HEAD' ? null : healthBody,
         {
           status: healthStatus === 'healthy' ? 200 : 503,
           headers: {


### PR DESCRIPTION
## Summary

- Global method filter now allows both GET and HEAD (HEAD is used by UptimeRobot health monitoring)
- `/healthz` returns a null body for HEAD requests (correct per HTTP spec)
- 405 response now includes `Allow: GET, HEAD` header

## Problem

UptimeRobot HTTP monitors send HEAD requests by default. The global method filter in `src/index.js` rejected all non-GET requests with a 405 before they could reach the `/healthz` route, causing UptimeRobot to report the service as down.

## Changes

- `src/index.js` only — no change to health check logic or any other routes

## Test plan

- [ ] Confirm `GET /healthz` still returns 200 with plain-text body
- [ ] Confirm `HEAD /healthz` returns 200 with no body (headers only)
- [ ] Confirm `POST /` (or any other non-GET/HEAD method) returns 405 with `Allow: GET, HEAD` header
- [ ] Confirm all existing routes behave identically for GET requests

https://claude.ai/code/session_01RVvxZ9XeZ4dg7SUsBMNJe4

---
_Generated by [Claude Code](https://claude.ai/code/session_01RVvxZ9XeZ4dg7SUsBMNJe4)_