### PR TITLE
fix(healthz): distinguish Nextcloud auth failures from other errors

### DIFF
--- a/src/index.js
+++ b/src/index.js
@@ -236,8 +236,11 @@ export default {
             },
             5000
           );
-          if (ncProbeRes.ok || ncProbeRes.status === 207 || ncProbeRes.status === 401) {
+          if (ncProbeRes.ok || ncProbeRes.status === 207) {
             details.push('nextcloud: reachable');
+          } else if (ncProbeRes.status === 401 || ncProbeRes.status === 403) {
+            healthStatus = 'degraded';
+            details.push('nextcloud: authentication failed (' + ncProbeRes.status + ') — check NEXTCLOUD_PASSWORD');
           } else {
             healthStatus = 'degraded';
             details.push('nextcloud: unexpected status ' + ncProbeRes.status);


### PR DESCRIPTION
## Summary

- `ok` or `207` → `nextcloud: reachable` (no change to healthy path)
- `401` or `403` → degraded with `nextcloud: authentication failed (<status>) — check NEXTCLOUD_PASSWORD`
- Any other non-ok status → degraded with `nextcloud: unexpected status <status>` (existing message, unchanged)

Previously, `401` was silently lumped into the "reachable" branch, hiding misconfigured credentials. `403` fell through to the generic unexpected-status path with no actionable guidance.

## Test plan

- [ ] Simulate a `401` response from Nextcloud; confirm `/healthz` returns `status: degraded` with the auth-failure detail message
- [ ] Simulate a `403` response; confirm same degraded detail message with `403` in the status code
- [ ] Simulate a `200`/`207` response; confirm `/healthz` still returns `nextcloud: reachable`
- [ ] Simulate a `503`; confirm `nextcloud: unexpected status 503` message is unchanged

https://claude.ai/code/session_01TQj9qgtmPBvQ5wcvEa51fk

---
_Generated by [Claude Code](https://claude.ai/code/session_01TQj9qgtmPBvQ5wcvEa51fk)_